### PR TITLE
Include namespace and separate RBAC by apiGroups.

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.0.13
-appVersion: "1.0.9"
+version: 1.0.14
+appVersion: "1.0.10"
 icon: "https://www.vantage.sh/nav-logo.svg"

--- a/charts/vantage-kubernetes-agent/templates/clusterrole.yaml
+++ b/charts/vantage-kubernetes-agent/templates/clusterrole.yaml
@@ -12,17 +12,23 @@ rules:
 - apiGroups: [""]
   resources: ["nodes/metrics"]
   verbs: ["get"]
-- apiGroups: ["", "apps", "batch"]
+- apiGroups: [""]
   resources:
   - "nodes"
   - "pods"
   - "namespaces"
-  - "replicasets"
   - "replicationcontrollers"
-  - "deployments"
-  - "statefulsets"
-  - "jobs"
-  - "cronjobs"
   - "persistentvolumes"
   - "persistentvolumeclaims"
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources:
+  - "replicasets"
+  - "deployments"
+  - "statefulsets"
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["batch"]
+  resources:
+  - "jobs"
+  - "cronjobs"
   verbs: ["get", "watch", "list"]

--- a/charts/vantage-kubernetes-agent/templates/secret.yaml
+++ b/charts/vantage-kubernetes-agent/templates/secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "vantage-kubernetes-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/vantage-kubernetes-agent/templates/service.yaml
+++ b/charts/vantage-kubernetes-agent/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "vantage-kubernetes-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
 spec:

--- a/charts/vantage-kubernetes-agent/templates/serviceaccount.yaml
+++ b/charts/vantage-kubernetes-agent/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vantage-kubernetes-agent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/vantage-kubernetes-agent/templates/statefulset.yaml
+++ b/charts/vantage-kubernetes-agent/templates/statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "vantage-kubernetes-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
 spec:

--- a/charts/vantage-kubernetes-agent/templates/tests/test-connection.yaml
+++ b/charts/vantage-kubernetes-agent/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "vantage-kubernetes-agent.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Allows for `helm template -n vantage` to generate yaml which includes the namespace. This is mainly a no-op for `helm upgrade` or `helm install`:
```
# Source: vantage-kubernetes-agent/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: vka-vantage-kubernetes-agent
  namespace: vantage
  labels:
    helm.sh/chart: vantage-kubernetes-agent-1.0.14
    app.kubernetes.io/name: vantage-kubernetes-agent
    app.kubernetes.io/instance: vka
    app.kubernetes.io/version: "1.0.10"
    app.kubernetes.io/managed-by: Helm
```

And more explicitly separates the `ClusterRole` by `apiGroups`. Overall permissions did not change.

And finally I snuck in an app version to support older clusters.