### PR TITLE
Allow users to persist to S3.

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.0.21
-appVersion: "1.0.15"
+version: 1.0.22
+appVersion: "1.0.17"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/templates/application.yaml
+++ b/charts/vantage-kubernetes-agent/templates/application.yaml
@@ -1,6 +1,13 @@
+{{- if .Values.agent.useDeployment  }}
+{{- $bucket := .Values.persistS3.bucket | required ".Values.persistS3.bucket is required for Deployments."}}
+{{- end }}
 {{- $clusterID := .Values.agent.clusterID | required ".Values.agent.clusterID is required."}}
 apiVersion: apps/v1
+{{- if .Values.agent.useDeployment  }}
+kind: Deployment
+{{- else }}
 kind: StatefulSet
+{{- end }}
 metadata:
   name: {{ include "vantage-kubernetes-agent.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -8,7 +15,12 @@ metadata:
     {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  {{- if .Values.agent.useDeployment }}
+  strategy:
+    type: Recreate
+  {{- else }}
   serviceName: vantage-agent
+  {{- end }}
   selector:
     matchLabels:
       {{- include "vantage-kubernetes-agent.selectorLabels" . | nindent 6 }}
@@ -77,6 +89,14 @@ spec:
             - name: VANTAGE_API_HOST
               value: "{{ . }}"
             {{ end }}
+            {{- with .Values.persistS3.bucket }}
+            - name: VANTAGE_PERSIST_S3_BUCKET
+              value: "{{ . }}"
+            {{ end }}
+            {{- with .Values.persistS3.prefix }}
+            - name: VANTAGE_PERSIST_S3_PREFIX
+              value: "{{ . }}"
+            {{ end }}
             {{- with .Values.persist }}
             - name: VANTAGE_PERSIST_DIR
               value: "{{ .mountPath }}"
@@ -91,11 +111,15 @@ spec:
               port: {{ .Values.service.name }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+
+          {{- if not .Values.agent.useDeployment }}
           {{- with .Values.persist }}
           volumeMounts:
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
-          {{ end }}
+          {{- end }}
+          {{- end }}
+  {{- if not .Values.agent.useDeployment }}
   {{- with .Values.persist }}
   volumeClaimTemplates:
   - metadata:
@@ -105,4 +129,5 @@ spec:
       resources:
         requests:
           storage: {{ .size }}
+  {{ end }}
   {{ end }}

--- a/charts/vantage-kubernetes-agent/templates/tests/test-connection.yaml
+++ b/charts/vantage-kubernetes-agent/templates/tests/test-connection.yaml
@@ -12,5 +12,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "vantage-kubernetes-agent.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "vantage-kubernetes-agent.fullname" . }}:{{ .Values.service.port }}/healthz']
   restartPolicy: Never

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -9,6 +9,8 @@ image:
   tag: ""
 
 agent:
+  # The agent can be deployed as a Deployment instead of StatefulSet but requires persistS3 to be present.
+  useDeployment: false
   debug: false
   # logLevel corresponds to https://pkg.go.dev/log/slog#Level
   # Info: 0
@@ -36,6 +38,13 @@ persist:
   mountPath: "/var/lib/vantage-agent"
   name: "data"
   size: "10Gi"
+
+# Configuration for persisting to S3. The agent will use IAM Roles for Service Accounts to authenticate. This should be setup prior to deploying the agent. See the agent docs for what policy is necessary, https://docs.vantage.sh/kubernetes_agent
+persistS3:
+  # S3 Bucket Name
+  bucket: null
+  # Prefix prepended to the standard '$CLUSTER_ID/filename.json.gz' key the agent uses.
+  prefix: null
 
 service:
   name: report


### PR DESCRIPTION
- Updates the app to 1.0.17 to support persisting to S3 and adds relevant configuration.
- Allows the application to be deployed as a Deployment using the `recreate` update strategy.