### PR TITLE
fix: allow setting storage class

### DIFF
--- a/charts/vantage-kubernetes-agent/templates/application.yaml
+++ b/charts/vantage-kubernetes-agent/templates/application.yaml
@@ -126,6 +126,9 @@ spec:
       name: {{ .name }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      {{- if .storageClassName }}
+      storageClassName: {{ .storageClassName }}
+      {{ end }}
       resources:
         requests:
           storage: {{ .size }}

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -38,6 +38,7 @@ persist:
   mountPath: "/var/lib/vantage-agent"
   name: "data"
   size: "10Gi"
+  storageClassName: "" # Optional, uses default if not set
 
 # Configuration for persisting to S3. The agent will use IAM Roles for Service Accounts to authenticate. This should be setup prior to deploying the agent. See the agent docs for what policy is necessary, https://docs.vantage.sh/kubernetes_agent
 persistS3:


### PR DESCRIPTION
We need to set the storage class for vantage to not use the default storage class. This enables that.