### PR TITLE
fix: vka values schema

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.json]
+indent_size = 4

--- a/charts/vantage-kubernetes-agent/templates/service.yaml
+++ b/charts/vantage-kubernetes-agent/templates/service.yaml
@@ -1,16 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "vantage-kubernetes-agent.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
+  name: { { include "vantage-kubernetes-agent.fullname" . } }
+  namespace: { { .Release.Namespace } }
+  labels: { { - include "vantage-kubernetes-agent.labels" . | nindent 4 } }
 spec:
-  type: {{ .Values.service.type }}
+  type: { { .Values.service.type } }
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.name }}
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.service.name } }
       protocol: TCP
-      name: {{ .Values.service.name }}
+      name: { { .Values.service.name } }
   selector:
-    {{- include "vantage-kubernetes-agent.selectorLabels" . | nindent 4 }}
+    { { - include "vantage-kubernetes-agent.selectorLabels" . | nindent 4 } }

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -43,6 +43,9 @@
                 "token": {
                     "type": "string"
                 },
+                "apiHost": {
+                    "type": "string"
+                },
                 "useDeployment": {
                     "type": "boolean"
                 }
@@ -111,10 +114,10 @@
             "type": "object",
             "properties": {
                 "bucket": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "prefix": {
-                    "type": "null"
+                    "type": "string"
                 }
             }
         },

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -37,6 +37,9 @@ agent:
 
   # Optional. When enabled, includes the labels of that pod's namespace in the pod metadata.
   collectNamespaceLabels: "false"
+
+  # Optional. Custom Vantage API Host. If not set, the default is used.
+  apiHost: ""
 persist:
   mountPath: "/var/lib/vantage-agent"
   name: "data"
@@ -69,11 +72,9 @@ resources:
     cpu: 100m
     memory: 50Mi
 
-
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-
 
 serviceAccount:
   annotations: {}


### PR DESCRIPTION
fixes #20 

- added editorconfig to ensure json indent is 4 (as the default is normally 2)
- apply formatting based on vscode k8s extension