### PR TITLE
Update to appVersion v1.0.20.

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.0.27
-appVersion: "1.0.18"
+version: 1.0.28
+appVersion: "1.0.20"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -91,7 +91,7 @@
             "type": "object"
         },
         "persist": {
-            "type": "object",
+            "type": ["object", "null"],
             "properties": {
                 "mountPath": {
                     "type": "string"
@@ -111,10 +111,10 @@
             "type": "object",
             "properties": {
                 "bucket": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "prefix": {
-                    "type": "null"
+                    "type": "string"
                 }
             }
         },

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -46,9 +46,9 @@ persist:
 # Configuration for persisting to S3. The agent will use IAM Roles for Service Accounts to authenticate. This should be setup prior to deploying the agent. See the agent docs for what policy is necessary, https://docs.vantage.sh/kubernetes_agent
 persistS3:
   # S3 Bucket Name
-  bucket: null
+  bucket: ""
   # Prefix prepended to the standard '$CLUSTER_ID/filename.json.gz' key the agent uses.
-  prefix: null
+  prefix: ""
 
 service:
   name: report


### PR DESCRIPTION
A signficant agent version upgrade, requires users to include `DaemonSets` to the RBAC permissions (https://github.com/vantage-sh/helm-charts/pull/21) and includes additional memory requirements for the agent (https://github.com/vantage-sh/helm-charts/pull/23). Depending on the amount of memory overhead, users may want to increase the memory request/limit and monitor for a new baseline. Impact will vary based on cluster profile.