### PR TITLE
feat: Add support for Pod Security Context

### DIFF
--- a/charts/vantage-kubernetes-agent/templates/application.yaml
+++ b/charts/vantage-kubernetes-agent/templates/application.yaml
@@ -157,6 +157,8 @@ spec:
               mountPath: {{ .mountPath }}
           {{- end }}
           {{- end }}
+    securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 6 }}
   {{- if not .Values.agent.useDeployment }}
   {{- with .Values.persist }}
   volumeClaimTemplates:

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -183,6 +183,9 @@
         "securityContext": {
             "type": "object"
         },
+        "podSecurityContext": {
+            "type": "object"
+        },
         "service": {
             "type": "object",
             "properties": {

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -114,6 +114,7 @@ appLabels: {}
 podLabels: {}
 podAnnotations: {}
 securityContext: {}
+podSecurityContext: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
There are configuration options available in the Pod Security Context that are not available at the container level. 

One of those is `fsGroup` which allows a user to modify the ownership of mounted volumes. This fixes the problem where the UID of the default user, root, is changed and then the user cannot write to the persistent volumes. 