### PR TITLE
fix: Use correct type for disableKubeTLSverify.

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.0.37
+version: 1.0.38
 appVersion: "1.0.27"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -24,7 +24,7 @@
                     "type": "boolean"
                 },
                 "disableKubeTLSverify": {
-                    "type": "string"
+                    "type": "boolean"
                 },
                 "gpu": {
                     "type": "object",


### PR DESCRIPTION
```
➜  vantage-kubernetes-agent git:(main) ✗ helm template -n vantage vka . --set agent.secret.name="secret-token" --set agent.clusterID="foo" --set agent.disableKubeTLSverify="true"
Error: values don't meet the specifications of the schema(s) in the following chart(s):
vantage-kubernetes-agent:
- agent.disableKubeTLSverify: Invalid type. Expected: string, given: boolean
```

vs.
```
➜  vantage-kubernetes-agent git:(mb/tls-skip-verify-schema) helm template -n vantage vka . --set agent.secret.name="secret-token" --set agent.clusterID="foo" --set agent.disableKubeTLSverify="true" | grep -A4 'VANTAGE_KUBE_SKIP_TLS_VERIFY'
            - name: VANTAGE_KUBE_SKIP_TLS_VERIFY
              value: "true"
            - name: VANTAGE_COLLECT_NAMESPACE_LABELS
              value: "false"
            - name: VANTAGE_API_TOKEN

```