### PR TITLE
fix: default value for disableKubeTLSverify was in the wrong type

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.0.38
+version: 1.0.39
 appVersion: "1.0.27"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -33,7 +33,7 @@ agent:
   allowedAnnotations: ""
 
   # Optional. Some cluster providers have self signed certificates on the kubelet. If you are seeing TLS errors, you can disable TLS verification here.
-  disableKubeTLSverify: "false"
+  disableKubeTLSverify: false
 
   # Optional. When enabled, includes the labels of that pod's namespace in the pod metadata.
   collectNamespaceLabels: "false"


### PR DESCRIPTION
Type for this value was changed in https://github.com/vantage-sh/helm-charts/commit/ce5619b40570560e6ca1f9e9a5902cc13d7c4f03, so the actual charts results in : 

```
helm template . --set agent.token=a --set agent.clusterID=b
Error: values don't meet the specifications of the schema(s) in the following chart(s):
vantage-kubernetes-agent:
- agent.disableKubeTLSverify: Invalid type. Expected: boolean, given: string
```

This PR change the default value type to a bool so the chart can be deployed again.