### PR TITLE
Release agent version 1.0.28.

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.0.39
-appVersion: "1.0.27"
+version: 1.0.40
+appVersion: "1.0.28"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"


### PR DESCRIPTION
Agent `1.0.28` adds support for collecting [sidecar init container](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/) resource request/limits.