### PR TITLE
feat: Add support for mounting volumes to the agent.

### DIFF
--- a/charts/vantage-kubernetes-agent/templates/application.yaml
+++ b/charts/vantage-kubernetes-agent/templates/application.yaml
@@ -138,7 +138,7 @@ spec:
             {{- with .Values.persist }}
             - name: VANTAGE_PERSIST_DIR
               value: "{{ .mountPath }}"
-            {{ end }}
+            {{- end }}
           ports:
             - name: {{ .Values.service.name }}
               containerPort: {{ .Values.service.port }}
@@ -149,14 +149,20 @@ spec:
               port: {{ .Values.service.name }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-
+          volumeMounts:
+          {{- if .Values.agent.volumeMounts }}
+          {{- toYaml .Values.agent.volumeMounts | nindent 10 }}
+          {{- end }}
           {{- if not .Values.agent.useDeployment }}
           {{- with .Values.persist }}
-          volumeMounts:
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
+          - name: {{ .name }}
+            mountPath: {{ .mountPath }}
           {{- end }}
           {{- end }}
+      volumes:
+      {{- if .Values.agent.volumes }}
+      {{- toYaml .Values.agent.volumes | nindent 6 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
   {{- if not .Values.agent.useDeployment }}

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -71,6 +71,12 @@
                 },
                 "useDeployment": {
                     "type": "boolean"
+                },
+                "volumes": {
+                    "type": "array"
+                },
+                "volumesMounts": {
+                    "type": "array"
                 }
             }
         },

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -60,6 +60,8 @@ agent:
     # Uses agent default if not specified: "/metrics"
     exporterPath: ""
 
+  volumes: []
+  volumeMounts: []
 
 persist:
   mountPath: "/var/lib/vantage-agent"


### PR DESCRIPTION
Tested this with and without volume and volumeMounts. Also upgraded to persist and not persist to s3, and upgraded with token as parameter. All resulted in booted and running agent on EKS. 

If there any other tests or verfications we can/should do, let me know.