### PR TITLE
Add Support for `dnsConfig` parameter for pod. 

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.1.4
+version: 1.1.5
 appVersion: "1.0.30"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/templates/application.yaml
+++ b/charts/vantage-kubernetes-agent/templates/application.yaml
@@ -56,6 +56,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8}}
       {{- end}}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -69,6 +69,19 @@ agent:
   volumes: []
   volumeMounts: []
 
+# Specifies the pod DNS configuration.
+dnsConfig: {}
+#  nameservers:
+#    - 1.2.3.4
+#  searches:
+#    - ns1.svc.cluster-domain.example
+#    - my.dns.search.suffix
+#  options:
+#    - name: ndots
+#      value: "1"
+#    - name: attempts
+#      value: "3"
+
 persist:
   mountPath: "/var/lib/vantage-agent"
   name: "data"


### PR DESCRIPTION
dnsConfig parameter is supported as standard across various public helm charts. Adding in support for that.
See more https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config