### PR TITLE
chore: Promote agent to 1.0.31.

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.1.5
-appVersion: "1.0.30"
+version: 1.2.0
+appVersion: "1.0.31"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"


### PR DESCRIPTION
Move to 1.2.0 since the underlying agent startup behavior changed slightly but in a backwards compatible way. It should be a net improvement for larger clusters and in most cases no real change.