### PR TITLE
Add PodDisruptionBudget support

### DIFF
--- a/charts/vantage-kubernetes-agent/templates/pdb.yaml
+++ b/charts/vantage-kubernetes-agent/templates/pdb.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- end}}
 spec:
   selector:
-    {{- include "vantage-kubernetes-agent.selectorLabels" . | nindent 4 }}
+    matchLabels:
+      {{- include "vantage-kubernetes-agent.selectorLabels" . | nindent 6 }}
   {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
 {{- end }}

--- a/charts/vantage-kubernetes-agent/templates/pdb.yaml
+++ b/charts/vantage-kubernetes-agent/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "vantage-kubernetes-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
+    {{- with .Values.appLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end}}
+spec:
+  selector:
+    {{- include "vantage-kubernetes-agent.selectorLabels" . | nindent 4 }}
+  {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
+{{- end }}

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -233,10 +233,10 @@
             "type": "object",
             "properties": {
                 "maxUnavailable": {
-                    "type": "integer"
+                    "type": ["integer", "string"]
                 },
                 "minAvailable": {
-                    "type": "integer"
+                    "type": ["integer", "string"]
                 }
             }
         }

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -228,6 +228,18 @@
         },
         "tolerations": {
             "type": "array"
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "properties": {
+                "maxUnavailable": {
+                    "type": "integer"
+                },
+                "minAvailable": {
+                    "type": "integer"
+                }
+            }
         }
+
     }
 }

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -142,3 +142,7 @@ podSecurityContext: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+# Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+  # minAvailable: 1


### PR DESCRIPTION
Add support for basic PDB configuration. Disabled by default to maintain current helm chart behaviour compatibility.