### PR TITLE
feat: Migrate to discovery endpoints API for dcgm-exporter discovery.

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.2.2
-appVersion: "1.0.31"
+version: 1.3.0
+appVersion: "1.1.0"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/templates/clusterrole.yaml
+++ b/charts/vantage-kubernetes-agent/templates/clusterrole.yaml
@@ -34,9 +34,9 @@ rules:
   - "cronjobs"
   verbs: ["get", "watch", "list"]
 {{- if .Values.agent.gpu.usageMetrics}}
-- apiGroups: [""]
+- apiGroups: ["discovery.k8s.io"]
   resources:
-  - "endpoints"
+  - "endpointslices"
   verbs: ["get", "watch", "list"]
 {{- end}}
 {{- if .Values.agent.argocdRollouts}}


### PR DESCRIPTION
`v1 Endpoints` is deprecated in kubernetes v1.33+. Upgrading to app version 1.1.0 without applying the new `ClusterRole` will cause any existing GPU deployments to fail to discover the intended `dcgm-exporters`. `EndpointSlices` became [stable in 1.21](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/) limiting GPU usage to kubernetes version 1.21+ (non-gpu usage metrics will continue to work in previous versions).