### PR TITLE
chore: Bump agent appVersion to 1.2.0

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.3.0
-appVersion: "1.1.0"
+version: 1.4.0
+appVersion: "1.2.0"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"


### PR DESCRIPTION
## Summary
- Bumps `appVersion` from `1.1.0` to `1.2.0` to match the [kubernetes-agent v1.2.0 release](https://github.com/vantage-sh/kubernetes-agent/releases/tag/v1.2.0)
- Bumps chart `version` from `1.3.0` to `1.4.0`

### What's in agent v1.2.0
- `GPUCapacityFromNode` helper for reading node GPU count
- `node_gpu_capacity` added to `clusters.csv` output

Made with [Cursor](https://cursor.com)