### PR TITLE
chore: Bump agent appVersion to 1.2.1

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.4.0
-appVersion: "1.2.0"
+version: 1.4.1
+appVersion: "1.2.1"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"


### PR DESCRIPTION
## Summary
- Bumps `appVersion` from `1.2.0` to `1.2.1`
- Bumps chart `version` from `1.4.0` to `1.4.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)