### PR TITLE
feat: Add agent.extraEnv for non-EKS AWS auth (e.g. GKE OIDC)

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.4.1
+version: 1.5.0
 appVersion: "1.2.1"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/templates/application.yaml
+++ b/charts/vantage-kubernetes-agent/templates/application.yaml
@@ -155,6 +155,9 @@ spec:
             - name: VANTAGE_POLLING_INTERVAL
               value: "{{ . }}"
             {{- end }}
+            {{- with .Values.agent.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: {{ .Values.service.name }}
               containerPort: {{ .Values.service.port }}

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -81,6 +81,9 @@
                 "volumesMounts": {
                     "type": "array"
                 },
+                "extraEnv": {
+                    "type": "array"
+                },
                 "pollingInterval": {
                     "type": "integer"
                 },

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -72,6 +72,25 @@ agent:
   volumes: []
   volumeMounts: []
 
+  # Optional. Additional environment variables to pass to the agent container.
+  # Entries are rendered verbatim and appended after the chart's built-in
+  # VANTAGE_* variables, so you can also use `valueFrom` (e.g. secretKeyRef).
+  #
+  # Useful for configuring AWS credentials on non-EKS clusters when using
+  # `persistS3.bucket` - for example, GKE clusters using AWS IAM OIDC
+  # federation via a projected ServiceAccount token mounted through
+  # `agent.volumes` / `agent.volumeMounts`.
+  #
+  # Do not redefine any VANTAGE_* variables the chart already renders; doing
+  # so will produce a duplicate env entry and fail pod admission.
+  extraEnv: []
+  #   - name: AWS_ROLE_ARN
+  #     value: arn:aws:iam::123456789012:role/vantage-agent-s3
+  #   - name: AWS_WEB_IDENTITY_TOKEN_FILE
+  #     value: /var/run/secrets/aws-iam/token
+  #   - name: AWS_REGION
+  #     value: us-east-1
+
 # Specifies the pod DNS configuration.
 dnsConfig: {}
 #  nameservers:


### PR DESCRIPTION
## Summary

Adds a new optional `agent.extraEnv` values list that is rendered verbatim at the tail of the agent container's `env:` block. This unblocks `persistS3.bucket` (S3 persistence for the agent's on-disk buffer) on clusters that don't run in EKS.

## Motivation

On EKS, S3 persistence is plug-and-play: users add `eks.amazonaws.com/role-arn` to the ServiceAccount and the EKS Pod Identity mutating webhook silently injects the env vars (`AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`) and projected token the AWS SDK needs.

On GKE / AKS / OKE / on-prem there is no such webhook. The correct pattern is AWS IAM OIDC federation: register the cluster's OIDC issuer in AWS IAM, create a role with a trust policy targeting `system:serviceaccount:vantage:vka-vantage-kubernetes-agent`, and let the AWS SDK's web-identity credential provider exchange a projected SA token (audience `sts.amazonaws.com`) for temporary creds.

That requires three env vars on the agent container:

- `AWS_ROLE_ARN`
- `AWS_WEB_IDENTITY_TOKEN_FILE`
- `AWS_REGION`

...plus a projected ServiceAccount token volume. The chart already exposes `agent.volumes` / `agent.volumeMounts` for the volume side, but there was no way to inject those env vars without forking the chart. This PR adds that one missing piece.

## Changes

- `values.yaml`: add `agent.extraEnv: []` with docs and a commented-out GKE OIDC example.
- `templates/application.yaml`: render `agent.extraEnv` at the end of the container's env block (3 lines).
- `values.schema.json`: add `agent.extraEnv: array`.
- `Chart.yaml`: bump `version` 1.4.1 → 1.5.0 (additive feature, no breaking changes).

## Backwards compatibility

`agent.extraEnv` defaults to an empty list. When unset, rendered output is byte-identical to 1.4.1. EKS IRSA users are unaffected.

## Validation

- `helm lint` passes for default values and for the GKE OIDC scenario.
- `helm template` produces identical default output when `extraEnv` is unset.
- `helm template` for the GKE OIDC scenario (StatefulSet and `agent.useDeployment=true`) correctly renders the AWS env vars at the tail of the env list and the projected `aws-iam-token` volume mounted at `/var/run/secrets/aws-iam`.
- Rendered manifest passes `kubectl apply --dry-run=client` for all 6 resources.

## Example values (GKE + OIDC → S3 persistence)

```yaml
agent:
  token: <vantage-api-token>
  clusterID: gke-ci-europe-west2

  extraEnv:
    - name: AWS_ROLE_ARN
      value: arn:aws:iam::<acct>:role/vantage-agent-s3
    - name: AWS_WEB_IDENTITY_TOKEN_FILE
      value: /var/run/secrets/aws-iam/token
    - name: AWS_REGION
      value: us-east-1

  volumes:
    - name: aws-iam-token
      projected:
        sources:
          - serviceAccountToken:
              audience: sts.amazonaws.com
              expirationSeconds: 3600
              path: token

  volumeMounts:
    - name: aws-iam-token
      mountPath: /var/run/secrets/aws-iam
      readOnly: true

persist: null
persistS3:
  bucket: my-vantage-agent-bucket
  prefix: gke
```

## Follow-ups (not in this PR)

- Docs update to [`kubernetes_agent#configure-agent-for-s3-persistence`](https://docs.vantage.sh/kubernetes_agent#configure-agent-for-s3-persistence) with a GKE-OIDC subsection using the example above.
- Potential guardrail: fail `helm template` if a `VANTAGE_*` name is supplied in `extraEnv` (would currently produce a duplicate env entry and be caught by pod admission, but a pre-render check would be friendlier).

## Test plan

- [x] `helm lint` clean on default values
- [x] `helm lint` clean on GKE OIDC values
- [x] `helm template` (StatefulSet) renders AWS env vars + projected token volume
- [x] `helm template --set agent.useDeployment=true` also renders correctly
- [x] Default render unchanged when `extraEnv` is unset
- [x] Rendered manifests pass `kubectl apply --dry-run=client`
- [ ] Install on a real GKE cluster with `persistS3.bucket` and confirm the agent starts, assumes the role, and writes objects under `<cluster-id>/` in the bucket
