### PR TITLE
chore: Bump agent appVersion to 1.2.2.

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.5.0
-appVersion: "1.2.1"
+version: 1.5.1
+appVersion: "1.2.2"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"


### PR DESCRIPTION
## What Changed

* Bumped version: 1.5.1
* Bumped appVersion: "1.2.2"