### PR TITLE
Add allowed labels to Chart

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.5.1
+version: 1.6.0
 appVersion: "1.2.2"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/templates/application.yaml
+++ b/charts/vantage-kubernetes-agent/templates/application.yaml
@@ -85,6 +85,10 @@ spec:
             - name: VANTAGE_ALLOWED_ANNOTATIONS
               value: "{{ .Values.agent.allowedAnnotations }}"
             {{- end}}
+            {{- if .Values.agent.allowedLabels}}
+            - name: VANTAGE_ALLOWED_LABELS
+              value: "{{ .Values.agent.allowedLabels }}"
+            {{- end}}
             {{- if .Values.agent.collectNamespaceLabels}}
             - name: VANTAGE_COLLECT_NAMESPACE_LABELS
               value: "{{ .Values.agent.collectNamespaceLabels }}"

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -11,6 +11,9 @@
                 "allowedAnnotations": {
                     "type": "string"
                 },
+                "allowedLabels": {
+                    "type": "string"
+                },
                 "argocdRollouts": {
                     "type": "boolean"
                 },

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -32,6 +32,9 @@ agent:
   # Optional. Comma separated list of allowed annotations to be sent to Vantage. Max 10 annotations. Note that values are truncated after 100 chars.
   allowedAnnotations: ""
 
+  # Optional. Comma separated list of allowed labels to be sent to Vantage. Max 10 labels.
+  allowedLabels: ""
+
   # Optional. Some cluster providers have self signed certificates on the kubelet. If you are seeing TLS errors, you can disable TLS verification here.
   disableKubeTLSverify: false
 
@@ -136,11 +139,9 @@ resources:
     cpu: 100m
     memory: 100Mi
 
-
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-
 
 serviceAccount:
   annotations: {}


### PR DESCRIPTION
## What Changed

I bumped the agent version in https://github.com/vantage-sh/helm-charts/pull/64 but I forgot to include updating new variables in the Chart. This PR properly exposes `VANTAGE_ALLOWED_LABELS`