### PR TITLE
feat(vka): network-collector DaemonSet + collector RBAC (VAN-1592)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,28 @@ pod network traffic to billing buckets (in-zone, in-region, cross-region, intern
 the agent pulls per-pod byte summaries from it each report cycle. When `enabled=false`
 (the default) none of these resources are rendered.
 
+### Conntrack byte accounting (required)
+
+The collector bills on per-flow byte counters from the kernel conntrack table. Those
+counters stay at zero unless **`net.netfilter.nf_conntrack_acct=1`** is set on every
+node ([kernel docs](https://www.kernel.org/doc/html/latest/networking/nf_conntrack-sysctl.html)).
+Many node images ship with this disabled by default. Without it the collector sees flows
+but reports zero bytes, so no pod network costs are attributed.
+
+Enable it cluster-wide **before** generating traffic — the kernel only counts bytes on
+connections opened *after* accounting is turned on. Verify on a node:
+
+    sysctl net.netfilter.nf_conntrack_acct   # should print 1
+
+To make it persistent across reboots, add a host sysctl drop-in (exact path varies by OS):
+
+    echo 'net.netfilter.nf_conntrack_acct=1' | sudo tee /etc/sysctl.d/99-vantage-conntrack-acct.conf
+    sudo sysctl --system
+
+On managed node groups that do not expose bootstrap hooks (for example EKS AL2023 managed
+node groups), apply the setting with a small privileged tuning DaemonSet or your platform's
+node-configuration mechanism. The chart does not set this sysctl for you.
+
 Traffic is classified by matching each flow's remote IP against a customer-provided
 CIDR -> zone/region map supplied via `agent.networkCost.subnets`. CIDRs are matched
 within the same IP family, so on dual-stack / IPv6 clusters you must include your IPv6

--- a/README.md
+++ b/README.md
@@ -30,6 +30,45 @@ To uninstall the chart, run the following command:
     
 See the [Vantage Kubernetes agent product documentation](https://docs.vantage.sh/kubernetes_agent) for additional details about the agent and its functionality.
 
+## Network cost collection (optional)
+
+Set `agent.networkCost.enabled=true` to deploy the per-node `vantage-network-collector`
+DaemonSet alongside the agent. The collector reads conntrack on each node to attribute
+pod network traffic to billing buckets (in-zone, in-region, cross-region, internet), and
+the agent pulls per-pod byte summaries from it each report cycle. When `enabled=false`
+(the default) none of these resources are rendered.
+
+Traffic is classified by matching each flow's remote IP against a customer-provided
+CIDR -> zone/region map supplied via `agent.networkCost.subnets`. CIDRs are matched
+within the same IP family, so on dual-stack / IPv6 clusters you must include your IPv6
+pod, service, and VPC ranges or that traffic falls through to the `internet` bucket.
+
+```yaml
+agent:
+  networkCost:
+    enabled: true
+    # port: 9012                     # collector listen + agent dial port (default 9012)
+    subnets:
+      - cidr: "10.0.0.0/16"
+        region: "us-east-1"
+        zone: "us-east-1a"
+      - cidr: "2600:1f18:abcd::/56"  # IPv6 / dual-stack clusters
+        region: "us-east-1"
+    # overrides:                     # optional CIDR -> bucket forcing list
+    #   - cidr: "203.0.113.0/24"
+    #     bucket: "internet"
+    # existingConfigMap: ""          # BYO ConfigMap with subnets.yaml instead of inline subnets
+```
+
+### Discovering subnet CIDRs
+
+- **AWS**: VPC CIDRs `aws ec2 describe-vpcs --query 'Vpcs[].{v4:CidrBlock,v6:Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock}'`; per-AZ subnets `aws ec2 describe-subnets --query 'Subnets[].{cidr:CidrBlock,az:AvailabilityZone}'`.
+- **GCP**: `gcloud compute networks subnets list --format='table(name,region,ipCidrRange,ipv6CidrRange)'`.
+- **Azure**: `az network vnet subnet list --resource-group <rg> --vnet-name <vnet> --query '[].{name:name,prefixes:addressPrefixes}'`.
+
+Map each subnet's CIDR to the AWS/GCP zone (or region) it lives in so cross-AZ traffic
+is billed as `in_zone` / `in_region` rather than `cross_region` or `internet`.
+
 ## Issues
 
 If you encounter any issues with the Helm Charts, please open a GitHub issue.

--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.7.0
-appVersion: "1.2.2"
+version: 1.8.0
+appVersion: "1.3"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.6.0
+version: 1.7.0
 appVersion: "1.2.2"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/templates/_helpers.tpl
+++ b/charts/vantage-kubernetes-agent/templates/_helpers.tpl
@@ -56,3 +56,21 @@ Create the name of the service account to use
 {{- define "vantage-kubernetes-agent.serviceAccountName" -}}
 {{- default (include "vantage-kubernetes-agent.fullname" .) .Values.serviceAccount.name }}
 {{- end }}
+
+{{/*
+Name used for the network-collector resources (DaemonSet, ServiceAccount, RBAC).
+*/}}
+{{- define "vantage-kubernetes-agent.networkCollector.fullname" -}}
+{{- printf "%s-network-collector" (include "vantage-kubernetes-agent.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Pod selector labels for the network-collector. The `app` label MUST stay equal
+to `vantage-network-collector` because the agent discovers collectors by listing
+pods with the label selector `app=vantage-network-collector`.
+*/}}
+{{- define "vantage-kubernetes-agent.networkCollector.selectorLabels" -}}
+app: vantage-network-collector
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: network-collector
+{{- end }}

--- a/charts/vantage-kubernetes-agent/templates/application.yaml
+++ b/charts/vantage-kubernetes-agent/templates/application.yaml
@@ -159,6 +159,12 @@ spec:
             - name: VANTAGE_POLLING_INTERVAL
               value: "{{ . }}"
             {{- end }}
+            {{- if .Values.agent.networkCost.enabled }}
+            - name: VANTAGE_NETWORK_METRICS
+              value: "true"
+            - name: VANTAGE_NETWORK_COLLECTOR_PORT
+              value: "{{ .Values.agent.networkCost.port }}"
+            {{- end }}
             {{- with .Values.agent.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/vantage-kubernetes-agent/templates/configmap-network.yaml
+++ b/charts/vantage-kubernetes-agent/templates/configmap-network.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.agent.networkCost.enabled (not .Values.agent.networkCost.existingConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "vantage-kubernetes-agent.fullname" . }}-network-subnets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
+data:
+  subnets.yaml: |
+    subnets:
+    {{- range .Values.agent.networkCost.subnets }}
+      - cidr: {{ .cidr | quote }}
+        {{- with .zone }}
+        zone: {{ . | quote }}
+        {{- end }}
+        {{- with .region }}
+        region: {{ . | quote }}
+        {{- end }}
+    {{- end }}
+    overrides:
+    {{- range .Values.agent.networkCost.overrides }}
+      - cidr: {{ .cidr | quote }}
+        bucket: {{ .bucket | quote }}
+    {{- end }}
+{{- end }}

--- a/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
+++ b/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
@@ -31,6 +31,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "vantage-kubernetes-agent.networkCollector.fullname" . }}
       # hostNetwork is required so conntrack on the node is visible to the collector.
+      # Nodes must also have net.netfilter.nf_conntrack_acct=1 or byte counters are zero.
       hostNetwork: true
       {{- with .Values.agent.networkCost.nodeSelector }}
       nodeSelector:

--- a/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
+++ b/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.agent.networkCost.enabled }}
+{{- $cm := .Values.agent.networkCost.existingConfigMap | default (printf "%s-network-subnets" (include "vantage-kubernetes-agent.fullname" .)) }}
+{{- $repo := .Values.agent.networkCost.image.repository | default .Values.image.repository }}
+{{- $tag := .Values.agent.networkCost.image.tag | default .Values.image.tag | default .Chart.AppVersion }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "vantage-kubernetes-agent.networkCollector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vantage-kubernetes-agent.networkCollector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vantage-kubernetes-agent.networkCollector.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "vantage-kubernetes-agent.networkCollector.fullname" . }}
+      # hostNetwork is required so conntrack on the node is visible to the collector.
+      hostNetwork: true
+      {{- with .Values.agent.networkCost.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.networkCost.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: network-collector
+          image: "{{ $repo }}:{{ $tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/network-collector"]
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN"]
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.agent.networkCost.port }}
+              protocol: TCP
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: VANTAGE_ADDR
+              value: ":{{ .Values.agent.networkCost.port }}"
+            - name: VANTAGE_LOG_LEVEL
+              value: "{{ .Values.agent.logLevel }}"
+          {{- with .Values.agent.networkCost.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: subnets
+              mountPath: /etc/vantage
+              readOnly: true
+      volumes:
+        - name: subnets
+          configMap:
+            name: {{ $cm }}
+{{- end }}

--- a/charts/vantage-kubernetes-agent/templates/network-rbac.yaml
+++ b/charts/vantage-kubernetes-agent/templates/network-rbac.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.agent.networkCost.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vantage-kubernetes-agent.networkCollector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "vantage-kubernetes-agent.networkCollector.fullname" . }}
+  labels:
+    {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
+rules:
+# The resolver lists/watches pods scoped to its own node (via a field selector
+# applied in code, which RBAC cannot enforce) and reads the node object for
+# zone/region labels.
+- apiGroups: [""]
+  resources:
+  - "pods"
+  - "nodes"
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - "configmaps"
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "vantage-kubernetes-agent.networkCollector.fullname" . }}
+  labels:
+    {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vantage-kubernetes-agent.networkCollector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "vantage-kubernetes-agent.networkCollector.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -92,6 +92,73 @@
                 },
                 "listLimit": {
                     "type": "integer"
+                },
+                "networkCost": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "subnets": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "cidr": {
+                                        "type": "string"
+                                    },
+                                    "zone": {
+                                        "type": "string"
+                                    },
+                                    "region": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["cidr"]
+                            }
+                        },
+                        "overrides": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "cidr": {
+                                        "type": "string"
+                                    },
+                                    "bucket": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["cidr", "bucket"]
+                            }
+                        },
+                        "existingConfigMap": {
+                            "type": "string"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "tolerations": {
+                            "type": "array"
+                        },
+                        "nodeSelector": {
+                            "type": "object"
+                        }
+                    }
                 }
             }
         },

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -72,6 +72,47 @@ agent:
     # Uses agent default if not specified: "/metrics"
     exporterPath: ""
 
+  # Optional. Per-node network cost collection. When enabled, the chart deploys
+  # the vantage-network-collector DaemonSet (reads conntrack to attribute pod
+  # network traffic to billing buckets) and tells the agent to pull per-pod
+  # byte summaries from it each report cycle.
+  #
+  # Requires an agent/collector image that includes the network collector
+  # (override image.tag if the chart appVersion predates it).
+  networkCost:
+    # When false (default) no DaemonSet, ConfigMap, collector RBAC, or agent
+    # network env vars are rendered.
+    enabled: false
+    # gRPC port the collector listens on and the agent dials. Single source of
+    # truth shared by the DaemonSet containerPort/VANTAGE_ADDR and the agent's
+    # VANTAGE_NETWORK_COLLECTOR_PORT.
+    port: 9012
+    # Optional. Override the collector image. Defaults to the top-level image.*
+    # values when left empty.
+    image:
+      repository: ""
+      tag: ""
+    # Required (unless existingConfigMap is set). List of VPC/VNet subnet CIDRs
+    # with zone/region info, rendered into the vantage-network-subnets ConfigMap.
+    # Each entry: { cidr: "10.0.0.0/8", zone: "us-east-1a", region: "us-east-1" }.
+    # zone is optional; region is derived from zone when omitted. Include IPv6
+    # CIDRs on dual-stack / IPv6 clusters or that traffic falls through to the
+    # internet bucket.
+    subnets: []
+    # Optional. List of CIDR->bucket overrides that win over subnet matches.
+    # Each entry: { cidr: "203.0.113.0/24", bucket: "internet" }.
+    # bucket is one of: in_zone, in_region, cross_region, internet, unknown.
+    overrides: []
+    # Optional. Name of a pre-existing ConfigMap holding subnets.yaml. When set,
+    # the chart does not render its own ConfigMap and `subnets`/`overrides` are
+    # ignored.
+    existingConfigMap: ""
+    # Optional. Resource requests/limits for the collector container.
+    resources: {}
+    # Optional. Scheduling controls for the collector DaemonSet.
+    tolerations: []
+    nodeSelector: {}
+
   volumes: []
   volumeMounts: []
 

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -79,6 +79,12 @@ agent:
   #
   # Requires an agent/collector image that includes the network collector
   # (override image.tag if the chart appVersion predates it).
+  #
+  # Node prerequisite: net.netfilter.nf_conntrack_acct=1 on every node. The
+  # kernel leaves conntrack byte counters at zero when this is off (the default
+  # on many images), so the collector cannot attribute traffic. Enable it
+  # cluster-wide before generating traffic; only new connections get counters.
+  # See the repo README "Conntrack byte accounting" section for details.
   networkCost:
     # When false (default) no DaemonSet, ConfigMap, collector RBAC, or agent
     # network env vars are rendered.


### PR DESCRIPTION
## Summary
Implements [VAN-1592](https://linear.app/vantage-sh/issue/VAN-1592). Ships the per-node `vantage-network-collector` via the existing chart, gated behind a new `agent.networkCost.enabled` value (default `false`).

- New `templates/daemonset-network.yaml` (`hostNetwork: true`, `NET_ADMIN`, `NODE_NAME` downward API, subnet ConfigMap mounted at `/etc/vantage`), `templates/configmap-network.yaml` (renders `subnets.yaml` from `subnets`/`overrides`, or skipped when `existingConfigMap` is set), and `templates/network-rbac.yaml` (dedicated collector ServiceAccount + ClusterRole `pods`/`nodes` get/list/watch + `configmaps` get + binding).
- Agent side: emits `VANTAGE_NETWORK_METRICS=true` and `VANTAGE_NETWORK_COLLECTOR_PORT` when enabled. The agent's existing cluster-wide `pods` get/watch/list already covers collector discovery, so no agent RBAC change was needed.
- Single `agent.networkCost.port` (default `9012`) is the source of truth shared by the collector `containerPort`/`VANTAGE_ADDR` and the agent's `VANTAGE_NETWORK_COLLECTOR_PORT`.
- `values.schema.json` updated; README gains a network-cost section with AWS/GCP/Azure subnet-discovery commands. MINOR bump `1.6.0` -> `1.7.0`.

Note: the collector binary listens via `--addr`/`VANTAGE_ADDR` (the issue text said `--listen_port`); the chart uses the real flag.

## Test plan
- [x] `helm lint` clean (default and `--strict` with `networkCost.enabled=true` + subnets/overrides)
- [x] `helm template` renders: enabled + inline subnets (DaemonSet/ConfigMap/collector RBAC + agent env all present, `subnets.yaml` correct)
- [x] enabled + `existingConfigMap` (no chart ConfigMap; volume points at the BYO name)
- [x] disabled / default (no DaemonSet, ConfigMap, collector RBAC, or agent network env — identical to prior chart)
- [x] non-default `port: 9100` (collector `containerPort`/`VANTAGE_ADDR` and agent `VANTAGE_NETWORK_COLLECTOR_PORT` all resolve to 9100)
- [x] End-to-end deploy on an IPv6 EKS cluster (follow-up, VAN-1674)

Made with [Cursor](https://cursor.com)