### PR TITLE
chore(vka): pin agent appVersion to 1.3.0

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.8.1
-appVersion: "1.3"
+version: 1.8.2
+appVersion: "1.3.0"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"


### PR DESCRIPTION
## Summary
- Pin `appVersion` to the immutable `1.3.0` image tag instead of the floating `1.3` minor tag.
- Bump chart `version` `1.8.1` → `1.8.2` so chart-releaser publishes the change.

## Context
The `1.3.0` agent image is built and live on quay (`quay.io/vantage-sh/kubernetes-agent:1.3.0`). Previous releases (`1.8.0`, `1.8.1`) referenced the floating `:1.3` tag; this pins to the exact patch so the chart points at an immutable image.

## Test plan
- [ ] Confirm chart-releaser publishes `vantage-kubernetes-agent-1.8.2`.
- [ ] Verify the rendered agent image is `quay.io/vantage-sh/kubernetes-agent:1.3.0`.

Made with [Cursor](https://cursor.com)