### PR TITLE
feat(vka): add eBPF network collector chart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ See the [Vantage Kubernetes agent product documentation](https://docs.vantage.sh
 ## Network cost collection (optional)
 
 Set `agent.networkCost.enabled=true` to deploy the per-node `vantage-network-collector`
-DaemonSet alongside the agent. The collector reads conntrack on each node to attribute
-pod network traffic to billing buckets (in-zone, in-region, cross-region, internet), and
-the agent pulls per-pod byte summaries from it each report cycle. When `enabled=false`
-(the default) none of these resources are rendered.
+DaemonSet alongside the agent. The collector reads conntrack or its own eBPF accounting
+program on each node to attribute pod network traffic to billing buckets (in-zone,
+in-region, cross-region, internet), and the agent pulls per-pod byte summaries from it
+each report cycle. When `enabled=false` (the default) none of these resources are rendered.
 
-### Conntrack byte accounting (required)
+### Conntrack byte accounting (conntrack source)
 
 The collector bills on per-flow byte counters from the kernel conntrack table. Those
 counters stay at zero unless **`net.netfilter.nf_conntrack_acct=1`** is set on every
@@ -60,6 +60,18 @@ On managed node groups that do not expose bootstrap hooks (for example EKS AL202
 node groups), apply the setting with a small privileged tuning DaemonSet or your platform's
 node-configuration mechanism. The chart does not set this sysctl for you.
 
+### Flow data source (conntrack or eBPF)
+
+`agent.networkCost.source` defaults to `conntrack`. On clusters where the CNI datapath
+bypasses kernel netfilter (for example, Cilium with kube-proxy replacement), set
+`agent.networkCost.source=ebpf` to use the collector's cgroup eBPF accounting program
+instead.
+
+The eBPF source does not require `net.netfilter.nf_conntrack_acct=1`. It does require a
+node kernel >= 5.8 with BTF and cgroup v2. When `source: ebpf`, the chart mounts the host
+cgroup root (`agent.networkCost.cgroupRoot`, default `/sys/fs/cgroup`) and grants the
+collector `CAP_BPF`, `CAP_PERFMON`, and `CAP_NET_ADMIN`.
+
 Traffic is classified by matching each flow's remote IP against a customer-provided
 CIDR -> zone/region map supplied via `agent.networkCost.subnets`. CIDRs are matched
 within the same IP family, so on dual-stack / IPv6 clusters you must include your IPv6
@@ -70,6 +82,9 @@ agent:
   networkCost:
     enabled: true
     # port: 9012                     # collector listen + agent dial port (default 9012)
+    # source: "conntrack"            # use "ebpf" on clusters bypassing kernel conntrack
+    # cgroupRoot: "/sys/fs/cgroup"   # only used when source is "ebpf"
+    # ebpfDebug: false               # only used when source is "ebpf"
     subnets:
       - cidr: "10.0.0.0/16"
         region: "us-east-1"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,38 @@ agent:
     # existingConfigMap: ""          # BYO ConfigMap with subnets.yaml instead of inline subnets
 ```
 
+### Scheduling on tainted nodes
+
+The collector is a DaemonSet, so it tries to run on every node. Kubernetes will
+**not** schedule it onto nodes that carry custom taints unless the collector pod
+has a matching toleration. If some of your nodes are tainted (a common setup for
+dedicated, GPU, or system node pools), the collector skips them and you get no
+network cost data for the pods running there.
+
+It is up to you to decide which nodes the collector should run on. Use
+`agent.networkCost.tolerations` to allow it onto tainted nodes, and
+`agent.networkCost.nodeSelector` / `agent.networkCost.affinity` to constrain it
+to (or away from) specific nodes. These apply only to the collector DaemonSet
+and are independent of the top-level `tolerations` / `nodeSelector` / `affinity`
+used by the agent workload.
+
+```yaml
+agent:
+  networkCost:
+    enabled: true
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "gpu"
+        effect: "NoSchedule"
+    # nodeSelector:                  # only run the collector on matching nodes
+    #   kubernetes.io/os: linux
+    # affinity: {}                   # standard pod affinity/anti-affinity rules
+    subnets:
+      - cidr: "10.0.0.0/16"
+        region: "us-east-1"
+```
+
 ### Discovering subnet CIDRs
 
 - **AWS**: VPC CIDRs `aws ec2 describe-vpcs --query 'Vpcs[].{v4:CidrBlock,v6:Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock}'`; per-AZ subnets `aws ec2 describe-subnets --query 'Subnets[].{cidr:CidrBlock,az:AvailabilityZone}'`.

--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.8.2
+version: 1.8.3
 appVersion: "1.3.0"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.8.3
+version: 1.8.4
 appVersion: "1.3.0"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
+++ b/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
@@ -42,6 +42,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.agent.networkCost.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: network-collector
           image: "{{ $repo }}:{{ $tag }}"

--- a/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
+++ b/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
@@ -2,6 +2,7 @@
 {{- $cm := .Values.agent.networkCost.existingConfigMap | default (printf "%s-network-subnets" (include "vantage-kubernetes-agent.fullname" .)) }}
 {{- $repo := .Values.agent.networkCost.image.repository | default .Values.image.repository }}
 {{- $tag := .Values.agent.networkCost.image.tag | default .Values.image.tag | default .Chart.AppVersion }}
+{{- $source := .Values.agent.networkCost.source | default "conntrack" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -30,8 +31,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "vantage-kubernetes-agent.networkCollector.fullname" . }}
-      # hostNetwork is required so conntrack on the node is visible to the collector.
-      # Nodes must also have net.netfilter.nf_conntrack_acct=1 or byte counters are zero.
+      # hostNetwork lets the collector observe node-local flow accounting.
+      # Conntrack mode also requires net.netfilter.nf_conntrack_acct=1 on nodes.
       hostNetwork: true
       {{- with .Values.agent.networkCost.nodeSelector }}
       nodeSelector:
@@ -48,7 +49,11 @@ spec:
           command: ["/network-collector"]
           securityContext:
             capabilities:
+              {{- if eq $source "ebpf" }}
+              add: ["BPF", "PERFMON", "NET_ADMIN"]
+              {{- else }}
               add: ["NET_ADMIN"]
+              {{- end }}
           ports:
             - name: grpc
               containerPort: {{ .Values.agent.networkCost.port }}
@@ -62,6 +67,14 @@ spec:
               value: ":{{ .Values.agent.networkCost.port }}"
             - name: VANTAGE_LOG_LEVEL
               value: "{{ .Values.agent.logLevel }}"
+            - name: VANTAGE_SOURCE
+              value: "{{ $source }}"
+            {{- if eq $source "ebpf" }}
+            - name: VANTAGE_CGROUP_ROOT
+              value: "{{ .Values.agent.networkCost.cgroupRoot }}"
+            - name: VANTAGE_EBPF_DEBUG
+              value: "{{ .Values.agent.networkCost.ebpfDebug }}"
+            {{- end }}
           {{- with .Values.agent.networkCost.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -70,8 +83,19 @@ spec:
             - name: subnets
               mountPath: /etc/vantage
               readOnly: true
+            {{- if eq $source "ebpf" }}
+            - name: cgroup
+              mountPath: {{ .Values.agent.networkCost.cgroupRoot }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: subnets
           configMap:
             name: {{ $cm }}
+        {{- if eq $source "ebpf" }}
+        - name: cgroup
+          hostPath:
+            path: {{ .Values.agent.networkCost.cgroupRoot }}
+            type: Directory
+        {{- end }}
 {{- end }}

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -167,6 +167,9 @@
                         },
                         "nodeSelector": {
                             "type": "object"
+                        },
+                        "affinity": {
+                            "type": "object"
                         }
                     }
                 }

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -102,6 +102,16 @@
                         "port": {
                             "type": "integer"
                         },
+                        "source": {
+                            "type": "string",
+                            "enum": ["conntrack", "ebpf"]
+                        },
+                        "cgroupRoot": {
+                            "type": "string"
+                        },
+                        "ebpfDebug": {
+                            "type": "boolean"
+                        },
                         "image": {
                             "type": "object",
                             "properties": {

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -73,17 +73,18 @@ agent:
     exporterPath: ""
 
   # Optional. Per-node network cost collection. When enabled, the chart deploys
-  # the vantage-network-collector DaemonSet (reads conntrack to attribute pod
-  # network traffic to billing buckets) and tells the agent to pull per-pod
-  # byte summaries from it each report cycle.
+  # the vantage-network-collector DaemonSet (reads conntrack or eBPF flow data
+  # to attribute pod network traffic to billing buckets) and tells the agent to
+  # pull per-pod byte summaries from it each report cycle.
   #
   # Requires an agent/collector image that includes the network collector
   # (override image.tag if the chart appVersion predates it).
   #
-  # Node prerequisite: net.netfilter.nf_conntrack_acct=1 on every node. The
-  # kernel leaves conntrack byte counters at zero when this is off (the default
-  # on many images), so the collector cannot attribute traffic. Enable it
-  # cluster-wide before generating traffic; only new connections get counters.
+  # Conntrack source prerequisite: net.netfilter.nf_conntrack_acct=1 on every
+  # node. The kernel leaves conntrack byte counters at zero when this is off
+  # (the default on many images), so the collector cannot attribute traffic.
+  # Enable it cluster-wide before generating traffic; only new connections get
+  # counters.
   # See the repo README "Conntrack byte accounting" section for details.
   networkCost:
     # When false (default) no DaemonSet, ConfigMap, collector RBAC, or agent
@@ -93,6 +94,16 @@ agent:
     # truth shared by the DaemonSet containerPort/VANTAGE_ADDR and the agent's
     # VANTAGE_NETWORK_COLLECTOR_PORT.
     port: 9012
+    # Flow data source. Use "conntrack" for the kernel netfilter conntrack table
+    # or "ebpf" for the collector's own cgroup eBPF accounting program. Use
+    # "ebpf" on clusters whose datapath bypasses kernel conntrack.
+    source: "conntrack"
+    # Host cgroup v2 mount to attach the eBPF accounting programs to. Only used
+    # when source is "ebpf"; the chart mounts the host path at this location.
+    cgroupRoot: "/sys/fs/cgroup"
+    # Optional. Log per-poll eBPF flow/delta counts. Only used when source is
+    # "ebpf".
+    ebpfDebug: false
     # Optional. Override the collector image. Defaults to the top-level image.*
     # values when left empty.
     image:

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -126,9 +126,15 @@ agent:
     existingConfigMap: ""
     # Optional. Resource requests/limits for the collector container.
     resources: {}
-    # Optional. Scheduling controls for the collector DaemonSet.
+    # Optional. Scheduling controls for the collector DaemonSet. The collector
+    # is a DaemonSet meant to run on every node, but Kubernetes will not place
+    # it on nodes carrying custom taints unless a matching toleration is set
+    # here. Add tolerations for any tainted nodes you want network costs from
+    # (or omit them to intentionally skip those nodes).
     tolerations: []
     nodeSelector: {}
+    # Optional. Node affinity/anti-affinity rules for the collector DaemonSet.
+    affinity: {}
 
   volumes: []
   volumeMounts: []


### PR DESCRIPTION
## Summary
- Expose network collector source settings in the Helm values and JSON schema.
- Render eBPF-specific environment variables, capabilities, and host cgroup mount when `agent.networkCost.source=ebpf`.
- Make the `vantage-network-collector` DaemonSet scheduling configurable (VAN-1637): add `agent.networkCost.affinity` alongside the existing `tolerations`/`nodeSelector`, and document that the collector will not run on nodes with custom taints unless a matching toleration is provided. It is up to users to decide which nodes the collector should cover.
- Document conntrack vs eBPF collector requirements and bump the chart version to 1.8.4.

## Related issues
- VAN-1592 (network collector DaemonSet + RBAC, eBPF source support)
- VAN-1637 (NetworkCollector YAML in Helm chart needs to be configurable)

## Test plan
- `helm lint ./charts/vantage-kubernetes-agent --set agent.clusterID=test --set agent.token=test --set agent.networkCost.enabled=true --set agent.networkCost.source=ebpf`
- `helm template ./charts/vantage-kubernetes-agent --set agent.clusterID=test --set agent.token=test --set agent.networkCost.enabled=true --set agent.networkCost.subnets[0].cidr=10.0.0.0/16 --set agent.networkCost.tolerations[0].key=dedicated --set agent.networkCost.tolerations[0].effect=NoSchedule --set agent.networkCost.affinity.nodeAffinity.x=y` and confirm `tolerations`/`affinity` render on the collector DaemonSet.


Made with [Cursor](https://cursor.com)