### PR TITLE
feat(vka): agent-side AWS network discovery (VAN-1784)

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.8.2
+version: 1.9.0
 appVersion: "1.3.0"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/templates/application.yaml
+++ b/charts/vantage-kubernetes-agent/templates/application.yaml
@@ -164,6 +164,32 @@ spec:
               value: "true"
             - name: VANTAGE_NETWORK_COLLECTOR_PORT
               value: "{{ .Values.agent.networkCost.port }}"
+            {{- if .Values.agent.networkCost.discovery.enabled }}
+            - name: VANTAGE_AWS_NETWORK_DISCOVERY
+              value: "true"
+            {{- with .Values.agent.networkCost.discovery.region }}
+            - name: VANTAGE_AWS_REGION
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.agent.networkCost.discovery.tagKey }}
+            - name: VANTAGE_SUBNET_DISCOVERY_TAG_KEY
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.agent.networkCost.discovery.tagValue }}
+            - name: VANTAGE_SUBNET_DISCOVERY_TAG_VALUE
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.agent.networkCost.discovery.interval }}
+            - name: VANTAGE_AWS_DISCOVERY_INTERVAL
+              value: "{{ . }}"
+            {{- end }}
+            # The agent writes the discovered ConfigMap into its own namespace so
+            # it matches the collector's mount below (see daemonset-network.yaml).
+            - name: VANTAGE_DISCOVERED_SUBNETS_CONFIGMAP
+              value: "{{ .Values.agent.networkCost.discovery.configMapName }}"
+            - name: VANTAGE_DISCOVERED_SUBNETS_CONFIGMAP_NAMESPACE
+              value: "{{ .Release.Namespace }}"
+            {{- end }}
             {{- end }}
             {{- with .Values.agent.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
+++ b/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
@@ -70,8 +70,26 @@ spec:
             - name: subnets
               mountPath: /etc/vantage
               readOnly: true
+            {{- if .Values.agent.networkCost.discovery.enabled }}
+            # Agent-discovered subnet ConfigMap, mounted as a directory (not
+            # subPath) so the kubelet refreshes the file in place and the
+            # collector's loader hot-reloads it. The default collector path is
+            # /etc/vantage/discovered/subnets.yaml, matching this mount + the
+            # ConfigMap's subnets.yaml key.
+            - name: discovered-subnets
+              mountPath: /etc/vantage/discovered
+              readOnly: true
+            {{- end }}
       volumes:
         - name: subnets
           configMap:
             name: {{ $cm }}
+        {{- if .Values.agent.networkCost.discovery.enabled }}
+        # Optional so the collector starts before the agent has written the
+        # discovered ConfigMap for the first time.
+        - name: discovered-subnets
+          configMap:
+            name: {{ .Values.agent.networkCost.discovery.configMapName }}
+            optional: true
+        {{- end }}
 {{- end }}

--- a/charts/vantage-kubernetes-agent/templates/network-discovery-rbac.yaml
+++ b/charts/vantage-kubernetes-agent/templates/network-discovery-rbac.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.agent.networkCost.enabled .Values.agent.networkCost.discovery.enabled }}
+# When AWS network discovery is enabled the agent renders the discovered subnet
+# topology into an agent-owned ConfigMap via server-side apply (VAN-1787). This
+# namespaced Role grants the agent ServiceAccount only the ConfigMap verbs it
+# needs in the release namespace; the manual (Helm-owned) subnet ConfigMap is a
+# separate object the agent never mutates.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "vantage-kubernetes-agent.fullname" . }}-network-discovery
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "vantage-kubernetes-agent.fullname" . }}-network-discovery
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vantage-kubernetes-agent.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vantage-kubernetes-agent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "vantage-kubernetes-agent.fullname" . }}-network-discovery
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/vantage-kubernetes-agent/templates/network-discovery-rbac.yaml
+++ b/charts/vantage-kubernetes-agent/templates/network-discovery-rbac.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.agent.networkCost.enabled .Values.agent.networkCost.discovery.enabled }}
 # When AWS network discovery is enabled the agent renders the discovered subnet
-# topology into an agent-owned ConfigMap via server-side apply (VAN-1787). This
+# topology into an agent-owned ConfigMap via server-side apply. This
 # namespaced Role grants the agent ServiceAccount only the ConfigMap verbs it
 # needs in the release namespace; the manual (Helm-owned) subnet ConfigMap is a
 # separate object the agent never mutates.

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -157,6 +157,29 @@
                         },
                         "nodeSelector": {
                             "type": "object"
+                        },
+                        "discovery": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "region": {
+                                    "type": "string"
+                                },
+                                "tagKey": {
+                                    "type": "string"
+                                },
+                                "tagValue": {
+                                    "type": "string"
+                                },
+                                "interval": {
+                                    "type": "string"
+                                },
+                                "configMapName": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 }

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -118,6 +118,46 @@ agent:
     # Optional. Scheduling controls for the collector DaemonSet.
     tolerations: []
     nodeSelector: {}
+    # Optional. Agent-side AWS network discovery. When enabled, the agent uses
+    # the EC2 API to discover VPC subnets, route tables, and S3 prefix lists and
+    # writes the result to an agent-owned "discovered" subnet ConfigMap that the
+    # collector hot-reloads. This supplements the manual `subnets` list above so
+    # per-subnet S3 egress paths (gateway-endpoint vs NAT/IGW) are classified
+    # from live AWS topology instead of only hand-authored CIDRs.
+    #
+    # Requires:
+    #   - networkCost.enabled = true (the collector consumes the discovered CM).
+    #   - An agent/collector image that includes AWS network discovery (override
+    #     image.tag if the chart appVersion predates it).
+    #   - EC2 read permissions on the agent ServiceAccount (IRSA / EKS Pod
+    #     Identity): ec2:DescribeSubnets, ec2:DescribeRouteTables,
+    #     ec2:DescribeManagedPrefixLists, ec2:GetManagedPrefixListEntries.
+    # The agent is fail-closed: without permissions it logs once and stays off,
+    # so enabling this on a cluster that lacks EC2 access is a no-op.
+    discovery:
+      # When true, renders the agent discovery env vars, the namespaced RBAC the
+      # agent needs to write the discovered ConfigMap, and mounts that ConfigMap
+      # into the collector.
+      enabled: false
+      # Optional. AWS region override. When empty the agent resolves the region
+      # from IMDS, then a node's topology.kubernetes.io/region label. Set this on
+      # clusters where IMDS is restricted.
+      region: ""
+      # Optional. Tag key used to seed subnet discovery (find the cluster's
+      # VPCs). Defaults in-agent to the Karpenter discovery tag
+      # (karpenter.sh/discovery) when left empty.
+      tagKey: ""
+      # Optional but recommended. Tag value paired with tagKey (e.g. the EKS
+      # cluster name) to scope discovery in shared VPCs. When empty, any subnet
+      # carrying tagKey matches (looser).
+      tagValue: ""
+      # Optional. Re-discovery interval as a Go duration (e.g. "10m"). Minimum
+      # 1m; the agent default is used when left empty.
+      interval: ""
+      # Name of the agent-owned ConfigMap the discovered topology is written to
+      # and the collector reads. Kept separate from the manual ConfigMap so a
+      # discovery refresh (or a `helm upgrade`) never clobbers manual entries.
+      configMapName: "vantage-network-subnets-discovered"
 
   volumes: []
   volumeMounts: []


### PR DESCRIPTION
## What changed?

Adds optional **agent-side AWS network discovery** to the `vantage-kubernetes-agent` chart (VAN-1784).

When `agent.networkCost.discovery.enabled=true` (alongside `agent.networkCost.enabled=true`) the chart now:

- **Agent env** (`application.yaml`): renders `VANTAGE_AWS_NETWORK_DISCOVERY=true` plus the optional region / tag key / tag value / interval, and the discovered ConfigMap name + namespace (`.Release.Namespace`).
- **Agent RBAC** (new `network-discovery-rbac.yaml`): a namespaced `Role`/`RoleBinding` granting the agent ServiceAccount `configmaps` get/list/watch/create/update/patch so it can write the agent-owned discovered subnet ConfigMap via server-side apply.
- **Collector mount** (`daemonset-network.yaml`): mounts the discovered ConfigMap (`optional: true`) at `/etc/vantage/discovered`, a directory mount so the kubelet refreshes the file in place and the collector's loader hot-reloads it.

The manual (`subnets`) ConfigMap is untouched — discovery writes a separate, agent-owned object so refreshes/`helm upgrade` never clobber manual entries.

New values under `agent.networkCost.discovery`: `enabled`, `region`, `tagKey`, `tagValue`, `interval`, `configMapName` (documented in `values.yaml` + `values.schema.json`).

Chart bumped `1.8.2` → `1.9.0`.

## Requirements to actually use it

- An agent/collector image that includes the discovery feature (override `image.tag`; the default `appVersion` predates it).
- EC2 read permissions on the agent ServiceAccount (IRSA / EKS Pod Identity): `ec2:DescribeSubnets`, `ec2:DescribeRouteTables`, `ec2:DescribeManagedPrefixLists`, `ec2:GetManagedPrefixListEntries`. The agent is fail-closed without them.

## Testing done

- `helm lint` passes.
- `helm template` with discovery enabled renders the discovery env, RBAC, and the optional collector mount; with discovery off (default) or `networkCost.enabled=false`, none of it renders (verified gating).

## Related

- Consumed by vantage-sh/infrastructure (kubernetes module) which grants the EC2 permissions and sets the discovery values.
