### PR TITLE
docs(vka): document network-collector scheduling on tainted nodes (VAN-1637)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,36 @@ agent:
     # existingConfigMap: ""          # BYO ConfigMap with subnets.yaml instead of inline subnets
 ```
 
+### Scheduling on tainted nodes
+
+The collector is a DaemonSet, so it tries to run on every node. Kubernetes will
+**not** schedule it onto nodes that carry custom taints unless the collector pod
+has a matching toleration. If some of your nodes are tainted (a common setup for
+dedicated, GPU, or system node pools), the collector skips them and you get no
+network cost data for the pods running there.
+
+It is up to you to decide which nodes the collector should run on. Use
+`agent.networkCost.tolerations` to allow it onto tainted nodes, and
+`agent.networkCost.nodeSelector` to constrain it to specific nodes. These apply
+only to the collector DaemonSet and are independent of the top-level
+`tolerations` / `nodeSelector` used by the agent workload.
+
+```yaml
+agent:
+  networkCost:
+    enabled: true
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "gpu"
+        effect: "NoSchedule"
+    # nodeSelector:                  # only run the collector on matching nodes
+    #   kubernetes.io/os: linux
+    subnets:
+      - cidr: "10.0.0.0/16"
+        region: "us-east-1"
+```
+
 ### Discovering subnet CIDRs
 
 - **AWS**: VPC CIDRs `aws ec2 describe-vpcs --query 'Vpcs[].{v4:CidrBlock,v6:Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock}'`; per-AZ subnets `aws ec2 describe-subnets --query 'Subnets[].{cidr:CidrBlock,az:AvailabilityZone}'`.

--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.8.2
+version: 1.8.3
 appVersion: "1.3.0"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -115,7 +115,11 @@ agent:
     existingConfigMap: ""
     # Optional. Resource requests/limits for the collector container.
     resources: {}
-    # Optional. Scheduling controls for the collector DaemonSet.
+    # Optional. Scheduling controls for the collector DaemonSet. The collector
+    # is a DaemonSet meant to run on every node, but Kubernetes will not place
+    # it on nodes carrying custom taints unless a matching toleration is set
+    # here. Add tolerations for any tainted nodes you want network costs from
+    # (or omit them to intentionally skip those nodes).
     tolerations: []
     nodeSelector: {}
 


### PR DESCRIPTION
## Summary

Documents how to schedule the network-collector DaemonSet, addressing [VAN-1637](https://linear.app/vantage-sh/issue/VAN-1637/networkcollector-yaml-in-helm-chart-needs-to-be-configurable).

The collector already supports `agent.networkCost.tolerations` and `agent.networkCost.nodeSelector` (merged in #71). What was missing was documentation: because the collector is a DaemonSet, Kubernetes will **not** place it on custom-tainted nodes without a matching toleration, so operators silently get no network cost data for pods on dedicated/GPU/system node pools.

- Add a "Scheduling on tainted nodes" section to the README explaining the behavior and how to configure `tolerations` / `nodeSelector`.
- Expand the inline comment on `agent.networkCost.tolerations` in `values.yaml`.
- Bump chart version `1.8.2` → `1.8.3`.

No template or schema changes — the configurable fields already exist.

## Testing

- `helm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)