### PR TITLE
chore(vka): bump agent appVersion to 1.3.1

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.9.0
-appVersion: "1.3.0"
+version: 1.9.1
+appVersion: "1.3.1"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"


### PR DESCRIPTION
## Summary
- Pin `appVersion` to kubernetes-agent `1.3.1`
- Bump chart version `1.9.0` → `1.9.1` so the release publishes

## Test plan
- [ ] Confirm CI chart lint/package succeeds
- [ ] After merge, verify the published chart `1.9.1` defaults to image tag `1.3.1`


Made with [Cursor](https://cursor.com)