### PR TITLE
feat(vka): expose network collector metrics and affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ agent:
     # existingConfigMap: ""          # BYO ConfigMap with subnets.yaml instead of inline subnets
 ```
 
-### Scheduling on tainted nodes
+### Scheduling collector pods
 
 The collector is a DaemonSet, so it tries to run on every node. Kubernetes will
 **not** schedule it onto nodes that carry custom taints unless the collector pod
@@ -92,9 +92,9 @@ network cost data for the pods running there.
 
 It is up to you to decide which nodes the collector should run on. Use
 `agent.networkCost.tolerations` to allow it onto tainted nodes, and
-`agent.networkCost.nodeSelector` to constrain it to specific nodes. These apply
-only to the collector DaemonSet and are independent of the top-level
-`tolerations` / `nodeSelector` used by the agent workload.
+`agent.networkCost.nodeSelector` or `agent.networkCost.affinity` to constrain it
+to specific nodes. These apply only to the collector DaemonSet and are
+independent of the top-level scheduling values used by the agent workload.
 
 ```yaml
 agent:
@@ -107,6 +107,14 @@ agent:
         effect: "NoSchedule"
     # nodeSelector:                  # only run the collector on matching nodes
     #   kubernetes.io/os: linux
+    # affinity:                      # for example, exclude unsupported EKS nodes
+    #   nodeAffinity:
+    #     requiredDuringSchedulingIgnoredDuringExecution:
+    #       nodeSelectorTerms:
+    #         - matchExpressions:
+    #             - key: eks.amazonaws.com/compute-type
+    #               operator: NotIn
+    #               values: [fargate, hybrid]
     subnets:
       - cidr: "10.0.0.0/16"
         region: "us-east-1"

--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.9.1
+version: 1.9.2
 appVersion: "1.3.1"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
+++ b/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
@@ -53,6 +53,9 @@ spec:
             - name: grpc
               containerPort: {{ .Values.agent.networkCost.port }}
               protocol: TCP
+            - name: metrics
+              containerPort: 8883
+              protocol: TCP
           env:
             - name: NODE_NAME
               valueFrom:

--- a/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
+++ b/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
@@ -37,6 +37,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.agent.networkCost.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.agent.networkCost.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -158,6 +158,9 @@
                         "nodeSelector": {
                             "type": "object"
                         },
+                        "affinity": {
+                            "type": "object"
+                        },
                         "discovery": {
                             "type": "object",
                             "properties": {

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -122,6 +122,10 @@ agent:
     # (or omit them to intentionally skip those nodes).
     tolerations: []
     nodeSelector: {}
+    # Optional. Pod affinity, anti-affinity, and node affinity rules for the
+    # collector DaemonSet. For example, use required node affinity to exclude
+    # Fargate or hybrid nodes where the collector cannot access conntrack.
+    affinity: {}
     # Optional. Agent-side AWS network discovery. When enabled, the agent uses
     # the EC2 API to discover VPC subnets, route tables, and S3 prefix lists and
     # writes the result to an agent-owned "discovered" subnet ConfigMap that the


### PR DESCRIPTION
## Summary
- expose the network collector Prometheus listener as the named `metrics` container port
- add `agent.networkCost.affinity` for collector-specific pod, anti-pod, and node affinity rules
- document excluding unsupported Fargate and hybrid nodes with required node affinity
- bump the chart version to 1.9.2

## Test plan
- [x] Run `helm lint` with network cost collection enabled
- [x] Render the network collector DaemonSet and verify the `metrics` port targets container port 8883
- [x] Render required node affinity and verify it appears under the collector pod spec
- [x] Validate `values.schema.json`
- [x] Run `git diff --check`