### PR TITLE
chore(vka): bump agent appVersion to 1.3.2

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.9.2
-appVersion: "1.3.1"
+version: 1.9.3
+appVersion: "1.3.2"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"


### PR DESCRIPTION
dont merge until 1.3.2 exists.

## Summary
- publish chart version 1.9.3
- default the Vantage Kubernetes agent image to v1.3.2

## Test plan
- [x] `helm lint charts/vantage-kubernetes-agent`

Made with [Cursor](https://cursor.com)