### PR TITLE
feat(vka): support network collector pod annotations

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.9.3
+version: 1.9.4
 appVersion: "1.3.2"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"

--- a/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
+++ b/charts/vantage-kubernetes-agent/templates/daemonset-network.yaml
@@ -2,6 +2,7 @@
 {{- $cm := .Values.agent.networkCost.existingConfigMap | default (printf "%s-network-subnets" (include "vantage-kubernetes-agent.fullname" .)) }}
 {{- $repo := .Values.agent.networkCost.image.repository | default .Values.image.repository }}
 {{- $tag := .Values.agent.networkCost.image.tag | default .Values.image.tag | default .Chart.AppVersion }}
+{{- $podAnnotations := mergeOverwrite (dict) (.Values.podAnnotations | default dict) (.Values.agent.networkCost.podAnnotations | default dict) }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -20,7 +21,7 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
+      {{- with $podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/vantage-kubernetes-agent/values.schema.json
+++ b/charts/vantage-kubernetes-agent/values.schema.json
@@ -152,6 +152,9 @@
                         "resources": {
                             "type": "object"
                         },
+                        "podAnnotations": {
+                            "type": "object"
+                        },
                         "tolerations": {
                             "type": "array"
                         },

--- a/charts/vantage-kubernetes-agent/values.yaml
+++ b/charts/vantage-kubernetes-agent/values.yaml
@@ -115,6 +115,9 @@ agent:
     existingConfigMap: ""
     # Optional. Resource requests/limits for the collector container.
     resources: {}
+    # Optional. Annotations applied only to network collector pods. Values here
+    # override duplicate keys from the chart-level podAnnotations map.
+    podAnnotations: {}
     # Optional. Scheduling controls for the collector DaemonSet. The collector
     # is a DaemonSet meant to run on every node, but Kubernetes will not place
     # it on nodes carrying custom taints unless a matching toleration is set


### PR DESCRIPTION
## Summary
- add `agent.networkCost.podAnnotations` for collector-only observability configuration
- merge collector annotations over chart-level pod annotations
- publish chart 1.9.4

## Test plan
- [x] `helm lint charts/vantage-kubernetes-agent --set agent.networkCost.enabled=true --set agent.networkCost.existingConfigMap=test`
- [x] render global and collector-specific annotations with `helm template`
- [x] validate `values.schema.json` with `jq`