### PR TITLE
chore(vka): bump agent to 1.3.3

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.9.4
-appVersion: "1.3.2"
+version: 1.9.5
+appVersion: "1.3.3"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"


### PR DESCRIPTION
## Summary
- Bump the Vantage Kubernetes agent from 1.3.2 to 1.3.3
- Bump the Helm chart from 1.9.4 to 1.9.5

## Test plan
- [x] `helm lint charts/vantage-kubernetes-agent`
- [x] `git diff --check`

## Cursor session
[View the Cursor session](https://cursor.com/dashboard/shared-chats?shareId=agent-and-helm-chart-version-bump-uqFXerqzgk1x)

Made with [Cursor](https://cursor.com)