### PR TITLE
chore(vka): bump agent appVersion to 1.3.3

### DIFF
--- a/charts/vantage-kubernetes-agent/Chart.yaml
+++ b/charts/vantage-kubernetes-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: vantage-kubernetes-agent
 description: Provisions the Vantage Kubernetes agent.
 type: application
-version: 1.9.4
-appVersion: "1.3.2"
+version: 1.9.5
+appVersion: "1.3.3"
 icon: "https://assets.vantage.sh/www/vantage_avatar-social.jpg"


### PR DESCRIPTION
## Summary
- publish chart 1.9.5
- point the chart at Kubernetes agent 1.3.3

## Test plan
- [x] `helm lint charts/vantage-kubernetes-agent --set agent.networkCost.enabled=true --set agent.networkCost.existingConfigMap=test`

Made with [Cursor](https://cursor.com)